### PR TITLE
김동현 / 6주차 / 3문제

### DIFF
--- a/miggule2/week6/BOJ_1026_보물.java
+++ b/miggule2/week6/BOJ_1026_보물.java
@@ -1,0 +1,37 @@
+package week6;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+
+public class BOJ_1026_보물 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] a = new int[n];
+        int[] b = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());;
+        for(int i = 0; i < n; i++){
+            a[i] = Integer.parseInt(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < n; i++){
+            b[i] = -Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(a);
+        Arrays.sort(b);
+
+        int result = 0;
+        for(int i = 0; i < n; i++){
+            result += a[i] * (-b[i]);
+        }
+
+        System.out.println(result);
+    }
+}

--- a/miggule2/week6/BOJ_13549_숨바꼭질3.java
+++ b/miggule2/week6/BOJ_13549_숨바꼭질3.java
@@ -12,10 +12,15 @@ public class BOJ_13549_숨바꼭질3 {
         sc.nextLine();
 
         Queue<Integer> queue = new LinkedList<>();
-        Integer[] times = new Integer[100000 + 1];
+        Integer[] times = new Integer[100000 + 1]; // visited가 의미 있는 경우엔 Integer == null 인 경우를 빼주면 되지만, 이번 경우엔 int[]에 Integer.MAX_VALUE를 대입해서 푸는 게 더 효율적이여 보임.
         queue.add(start);
-        times[start] = 0;
+        times[start] = 0; // 시작 칸의 경우 0으로 초기화
 
+        //bfs풀이 시작
+        // 1. 제일 처음엔 start만 queue에 담긴채로 시작.
+        // 2. +1,-1 했을 경우와 *2 했을 경우의 시간(비용)이 다르기 때문에 이미 방문한 노드더라도, 나중에 방문한 경우가 시간이 덜 걸릴 수 있기 때문에
+        // times[다음] 과 times[현재]+1 or +0 을 비교해서 더 작은 경우에 갱신해주고, queue에 다음 숫자를 삽입
+        // 3. 2번 과정을 반복
         while (!queue.isEmpty()) {
             int now = queue.poll();
 

--- a/miggule2/week6/BOJ_13549_숨바꼭질3.java
+++ b/miggule2/week6/BOJ_13549_숨바꼭질3.java
@@ -1,0 +1,29 @@
+package week6;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class BOJ_13549_숨바꼭질3 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int start = sc.nextInt();
+        int end = sc.nextInt();
+        sc.nextLine();
+
+        Queue<Integer> queue = new LinkedList<>();
+        Integer[] times = new Integer[100000 + 1];
+        queue.add(start);
+        times[start] = 0;
+
+        while (!queue.isEmpty()) {
+            int now = queue.poll();
+
+            if (now+1 <= 100000 && (times[now+1] == null || times[now+1] > times[now]+1)) {queue.add(now+1); times[now+1] = times[now]+1;}
+            if (now-1 >= 0 && (times[now-1] == null || times[now-1] > times[now]+1)) {queue.add(now-1); times[now-1] = times[now]+1;}
+            if (2*now <= 100000 && (times[2*now] == null || times[2*now] > times[now])) {queue.add(2*now); times[2*now] = times[now];}
+        }
+
+        System.out.println(times[end]);
+    }
+}

--- a/miggule2/week6/BOJ_1916_최소비용구하기.java
+++ b/miggule2/week6/BOJ_1916_최소비용구하기.java
@@ -1,0 +1,57 @@
+package week6;
+
+import java.util.*;
+import java.io.*;
+
+public class BOJ_1916_최소비용구하기 {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int v = Integer.parseInt(br.readLine());
+        int e = Integer.parseInt(br.readLine());
+
+        HashMap<Integer,ArrayList<int[]>> map = new HashMap<>();
+        int[] array = new int[v+1];
+
+        for(int i = 1; i <= v; i++){
+            map.put(i, new ArrayList<>());
+            array[i] = Integer.MAX_VALUE;
+        }
+
+        for(int i = 0; i < e; i++){
+            st = new StringTokenizer(br.readLine());
+            int start  = Integer.parseInt(st.nextToken());
+            int end =  Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+
+            map.get(start).add(new int[]{weight, end});
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        Queue<int[]> heap = new PriorityQueue<>(Comparator.comparingInt(a->a[0]));
+        boolean[] visited = new boolean[v+1];
+        array[start] = 0;
+        heap.add(new int[]{0,start});
+        while(!heap.isEmpty()){
+            int[] now = heap.poll();
+            int nowWeight = now[0];
+            int nowStop = now[1];
+            if(visited[nowStop]) continue;
+
+            visited[nowStop] = true;
+            for(int[] value : map.get(nowStop)){
+                int valueWeight = value[0];
+                int valueStop = value[1];
+                if(visited[valueStop] || array[valueStop] <= array[nowStop] + valueWeight) continue;
+
+                array[valueStop] = array[nowStop] + valueWeight;
+                heap.add(new int[] {array[valueStop], valueStop});
+            }
+        }
+
+        System.out.println(array[end]);
+    }
+}

--- a/miggule2/week6/BOJ_1916_최소비용구하기_다익스트라시간초과.java
+++ b/miggule2/week6/BOJ_1916_최소비용구하기_다익스트라시간초과.java
@@ -1,0 +1,53 @@
+package week6;
+
+import java.util.*;
+import java.io.*;
+
+public class BOJ_1916_최소비용구하기_다익스트라시간초과 {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int v = Integer.parseInt(br.readLine());
+        int e = Integer.parseInt(br.readLine());
+
+        HashMap<Integer,ArrayList<int[]>> map = new HashMap<>();
+        int[] array = new int[v+1];
+
+        for(int i = 1; i <= v; i++){
+            map.put(i, new ArrayList<>());
+            array[i] = Integer.MAX_VALUE;
+        }
+
+        for(int i = 0; i < e; i++){
+            st = new StringTokenizer(br.readLine());
+            int start  = Integer.parseInt(st.nextToken());
+            int end =  Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+
+            map.get(start).add(new int[]{weight, end});
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        Queue<int[]> heap = new PriorityQueue<>(Comparator.comparingInt(a->a[0]));
+        array[start] = 0;
+        heap.add(new int[]{0,start});
+        while(!heap.isEmpty()){
+            int[] now = heap.poll();
+            int nowWeight = now[0];
+            int nowStop = now[1];
+            for(int[] value : map.get(nowStop)){
+                int valueWeight = value[0];
+                int valueStop = value[1];
+                if(array[valueStop] <= nowWeight + valueWeight) continue;
+
+                array[valueStop] = nowWeight + valueWeight;
+                heap.add(new int[] {array[valueStop], valueStop});
+            }
+        }
+
+        System.out.println(array[end]);
+    }
+}


### PR DESCRIPTION
### [백준] 최소비용구하기 / 골드5 / 풀이 참고
* 다익스트라 알고리즘에 대한 이해가 부족해서 방문한 노드에 대해서는 다시 heap에 넣을 필요가 없다는 걸 몰랐다.
* 그래서 해당 문제의 풀이를 찾아서 다시 공부하여 다음날에 직접 코드를 짜서 제출.
* 다익스트라에 대한 이해가 조금 더 늘 수 있었던 문제

### [백준] 숨바꼭질3 / 골드5 / 40분
* bfs 활용 문제.
* 이 문제의 기본형인 숨바꼭질의 경우에는 +1,-1 인 경우와 *2 인 경우의 비용이 같아서 먼저 방문한 경우가 무조건 시간이 덜 걸리는 경우 이지만
* 이 경우는 비용이 다르기 때문에 기존에 방문한 경우더라도 비용의 크기를 비교해서 갱신해줘야 하는 차이점이 있었음.
* 비용이 같은 경우와 다른 경우의 풀이 차이를 알 수 있는 문제.

### [백준] 보물 / 실버4 / 15분
* 예전에 풀었던 문제와 아주 비슷한 문제.
* 문제의 조건은 B의 배열을 움직이면 안 된다고 했지만, 실제 문제를 풀 경우에는 a,b 둘 다 정렬해서 그 둘의 요소 합을 계산한 결과는 B의 배열이 가만히 있는 채로 a의 배열만 움직이는 경우와 실제로는 동일.