### PR TITLE
채태영 / 7주차 / 3문제

### DIFF
--- a/tttyoung/week_7_그래프탐색/boj_10866_덱.py
+++ b/tttyoung/week_7_그래프탐색/boj_10866_덱.py
@@ -1,0 +1,46 @@
+import sys
+from collections import deque 
+
+num = int(sys.stdin.readline())
+dq = deque()
+for i in range(num):
+    cmlistqu = sys.stdin.readline().split()
+
+    if cmlistqu[0] == "push_front":
+        dq.appendleft(int(cmlistqu[1])) #왼쪽에 요소를 추가
+
+    elif cmlistqu[0] == "push_back":
+        dq.append(int(cmlistqu[1]))
+
+    elif cmlistqu[0] == "pop_front":
+        if len(dq) == 0:
+            print(-1)
+        else:
+            print(dq.popleft()) #가장 왼쪽 요소가 나옴
+
+    elif cmlistqu[0] == "pop_back":
+        if len(dq) == 0:
+            print(-1)
+        else:
+            print(dq.pop()) #가장 오른쪽쪽 요소가 나옴
+
+    elif cmlistqu[0] == "size":
+        print(len(dq))
+
+    elif cmlistqu[0] == "empty":
+        if len(dq) == 0:
+            print(1)
+        else:
+            print(0)
+
+    elif cmlistqu[0] == "front":
+        if len(dq) == 0:
+            print(-1)
+        else:
+            print(dq[0])
+
+    elif cmlistqu[0] == "back":
+        if len(dq) == 0:
+            print(-1)
+        else:
+            print(dq[-1])

--- a/tttyoung/week_7_그래프탐색/boj_11724_연결요소의개수.py
+++ b/tttyoung/week_7_그래프탐색/boj_11724_연결요소의개수.py
@@ -1,0 +1,48 @@
+node, edge = map(int, input().split())
+edgelist = []
+
+for i in range(edge):
+    e = list(map(int, input().split()))
+    edgelist.append(e)
+
+def change(edgelist, node): #간선목록을 인접리스트(딕셔너리)로 바꿔주는 함수
+    edgedic= {}
+    for i in range(node):
+        edgedic[i+1] = []
+    for a, b in edgelist:
+        if a in edgedic:
+            edgedic[a].append(b)
+        if b in edgedic:
+            edgedic[b].append(a)
+    return edgedic
+
+def bfs(edgedic, start, done):#done을 이용해 재귀를 하기 위해서 매개변수로 위치함.
+    qu = []
+    qu.append(start)
+    done.add(start)
+
+    while qu:
+        p = qu.pop(0)
+        for num in edgedic[p]:
+            if num not in done:
+                qu.append(num)
+                done.add(num)
+
+count = 0
+done = set()
+edgedic = change(edgelist, node)
+
+for i in range(1, node + 1): #연결요소 개수 세기위한 함수, 1부터 n까지의 노드 개수만큼 for문을 반복하여 노드가 done에 없으면 재귀해서 연결요소묶음 찾기. 이미 연결한 묶음의 요소들은 모두 done에 추가되어있음.
+    if i not in done:
+        bfs(edgedic, i, done)
+        count += 1
+
+print(count)
+
+
+
+
+
+
+
+

--- a/tttyoung/week_7_그래프탐색/boj_1181_단어정렬.py
+++ b/tttyoung/week_7_그래프탐색/boj_1181_단어정렬.py
@@ -1,0 +1,12 @@
+num = int(input())
+strlist = []
+for i in range(num):
+    a = input()
+    strlist.append(a)
+
+strlist = list(set(strlist))
+strlist.sort()
+strlist.sort(key = len)
+
+for i in range(len(strlist)):
+    print(strlist[i])


### PR DESCRIPTION
[boj] 11724_연결요소의개수 / 실버2 / 2시간
큐를 이용하여 bfs로 풀었음. 입력을 간선 목록을 받기 때문에 이를 인접리스트(딕셔너리)로 바꿔주는 함수 change를 작성. 마지막에 연결요소 개수를 찾기 위해 for문으로 하나씩 돌면서 done에 추가된 적이 있으면 넘어가고 없으면 count+1을 하여 연결된 그룹의 개수를 찾음.

[boj] 1181_단어정렬 / 실버5 / 20분
set을 이용하여 중복을 먼저 없애는 작업을 한 뒤 sort()를 하여 사전순으로 먼저 정렬함. 그 후에 sort(key = len)을 이용하여 이미 사전순으로 정렬된 문자열들을 길이에 따라 정렬하는 작업을 함. 길이 정렬을 먼저 하게된다면 정렬 순서가 꼬이게 되므로 순서를 지켜야함.

[boj] 10866_덱 / 실버4 / 10분
덱의 양뱡향 성질을 이용하여 덱의 기본적인 특징을 알아내는 문제. 큐2와 유사하지만 양뱡향으로 추가하고 꺼내는 작업이 추가됨