### PR TITLE
채태영 / 8주차 / 3문제

### DIFF
--- a/tttyoung/week_8/boj_1260_dfs와bfs.py
+++ b/tttyoung/week_8/boj_1260_dfs와bfs.py
@@ -1,0 +1,57 @@
+from collections import defaultdict 
+
+n, m, v = map(int, input().split())
+edgelist = []
+
+for i in range(m):
+    edgelist.append(list(map(int, input().split())))
+
+def change(edgelist, n): #간선목록을 인접리스트(딕셔너리)로 바꿔주는 함수
+    edgedic= {}
+    for i in range(n): #start값이 어떠한 노드랑도 연결이 안되어있을 경우 keyerror가 남. 따라서 혼자 있는 노드도 비어있는 딕셔너리를 만들어줘야함.
+        edgedic[i+1] = []
+    for a, b in edgelist:
+        if a in edgedic:
+            edgedic[a].append(b)
+        if b in edgedic:
+            edgedic[b].append(a)
+    return edgedic
+
+
+def dfs_stack(edgedic, start):
+    st = [start] #스택 초기화
+    done = set()
+    result = []
+
+    while st:
+        s = st.pop()
+        if s not in done:
+            done.add(s)
+            result.append(s)
+            st.extend(reversed(edgedic[s])) #스택에 이웃 노드 추가
+    print(*result)
+
+def bfs(edgedic, start):
+    qu = []
+    done = set()
+    result = []
+
+    qu.append(start)
+    done.add(start)
+
+    while qu:
+        p = qu.pop(0)
+        result.append(p)
+        for i in edgedic[p]:
+            if i not in done:
+                qu.append(i)
+                done.add(i)
+    print(*result)
+   
+edgedic = change(edgelist, n)
+for key in edgedic: #딕셔너리 밸류값들을 오름차순으로 정리함.
+    edgedic[key].sort()
+
+dfs_stack(edgedic, v)
+bfs(edgedic, v)
+

--- a/tttyoung/week_8/boj_2178_미로탐색.py
+++ b/tttyoung/week_8/boj_2178_미로탐색.py
@@ -1,0 +1,24 @@
+from collections import deque
+n, m = map(int, input().split())
+maze = []
+for _ in range(n):
+    maze.append(list(map(int, input())))
+
+dx = [1, -1, 0, 0] #상하좌우로 하나씩 이동하는 변수, 이를 통해 상하좌우에 1이 있는지 0(벽)이 있는지 확인.
+dy = [0, 0, -1, 1]
+
+def bfs_maze(x, y):
+    qu = deque()
+    qu.append((x, y))
+
+    while qu:
+        x, y = qu.popleft()
+        for i in range(4): #상하좌우 확인하는 과정
+            nx, ny = x + dx[i], y + dy[i] #이동한 거리만큼 더함.
+            if 0 <= nx < n and 0 <= ny < m and maze[nx][ny] == 1: #nx, ny가 미로 범위 안에 있으면서 그 좌표에 해당하는 칸이 1이라면 큐에 추가해주고 해당 칸에 1을 더하여 그 칸의 값을 거리로 알 수 있게 해줌.
+                qu.append((nx, ny))
+                maze[nx][ny] = maze[x][y] + 1
+
+    return maze[n-1][m-1] 
+
+print(bfs_maze(0, 0))

--- a/tttyoung/week_8/boj_2644_촌수계산.py
+++ b/tttyoung/week_8/boj_2644_촌수계산.py
@@ -1,0 +1,53 @@
+from collections import defaultdict 
+
+num = int(input())
+a, b = map(int, input().split())
+edgenum = int(input())
+edgelist = []
+for i in range(edgenum):
+    edgelist.append(list(map(int, input().split())))
+
+edgedic= {}
+for i in range(num):
+    edgedic[i+1] = []
+for x, y in edgelist:
+    if x in edgedic:
+        edgedic[x].append(y)
+    if y in edgedic:
+        edgedic[y].append(x)
+
+
+def bfs(edgelist, start, end):
+    qu = []
+    done = set()
+    count = 0
+
+    qu.append(start)
+    done.add(start)
+    flag = False
+    while qu:
+        count+=1 #count를 pop하기 전의 qu의 갯수 동안은 동일하게 유지해야함.
+        
+        for i in range(len(qu)):
+            p = qu.pop(0)
+            if p == end:
+                flag = True #만약 end값을 만나게 된다면 나머지 while문을 돌지 않고 그대로 나가게 하기
+                #end값을 만나더라도 while문이 반복되게 된다면 나머지 노드들을 방문하면서 count값이 커지게됨. 그러면 우리가 원하는 end지점까지의 촌수가 아닌 다른 count값이 나오게됨.
+                break
+
+            for i in edgelist[p]:
+                if i not in done:
+                    qu.append(i)
+                    done.add(i)        
+        if flag == True:
+            break
+            
+    if end in done:
+        print(count-1)                                
+    else:
+        print(-1)
+    
+bfs(edgedic, a, b)
+
+
+#count를 언제 해야할지, end를 찾았을대 어떻게 종료할지, 찾지못했을때 -1 출력


### PR DESCRIPTION
[boj] 2178_미로탐색 / 실버1 / 4시간
이번주 문제중 제일 어려웠던 문제. 좌표를 이중리스트로 나타낸 후 시작위치에서부터 상하좌우로 한칸씩 이동하는 경우를 for문을 통해 돌리고 좌표를 수정한 후에 그 좌표가 미로 범위안에 해당하며 이동한 좌표가 0(벽)이 아닌 1인 경우에 큐에 좌표를 저장하고 해당 좌표의 값을 1에서 +1 하여 거리를 나타내게 해야함. 

[boj] 1260_dfs와bfs / 실버2 / 2시간
dfs와 bfs를 이용하여 탐색과정을 나타내는 문제. start값이 어떠한 노드와도 연결이 안되어있으면 keyerror가 나기때문에 딕셔너리를 하나씩 만들어줘야함. 추가로 딕셔너리를 오름차순으로 정리하는 코드를 작성해야함.

[boj] 2644_촌수계산 / 실버2 / 4시간
문제자체는 간단한 문제이지만 전체 연결되어있는 간선 갯수가 아닌 end까지의 최단거리를 구해야함. 따라서 qu에 있는 요소만큼 for문을 돌게하고 그 갯수동안은 count의 갯수가 동일해야함.