### PR TITLE
김동현 / 11주차 / 3문제

### DIFF
--- a/miggule2/week11/BOJ_13305_주유소.java
+++ b/miggule2/week11/BOJ_13305_주유소.java
@@ -1,0 +1,45 @@
+package week11;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_13305_주유소 {
+    static int[] distances;
+    static int[] prices;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        distances = new int[n-1];
+        prices = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < n-1; i++){
+            distances[i] = Integer.parseInt(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i< n; i++){
+            prices[i] = Integer.parseInt(st.nextToken());
+        }
+
+        System.out.println(greedy(0,n-1));
+    }
+
+    private static long greedy(int start, int end){
+        if(start == end) return 0;
+        int index = end;
+        int min = Integer.MAX_VALUE;
+        for(int i = start; i < end; i++){
+            if(min >= prices[i]){
+                min = prices[i];
+                index = i;
+            }
+        }
+        long distance = 0;
+        for(int i = index; i < end; i++){
+            distance += distances[i];
+        }
+        long price = prices[index]*distance;
+        return greedy(start,index) + price;
+    }
+}

--- a/miggule2/week11/BOJ_1789_수들의합.java
+++ b/miggule2/week11/BOJ_1789_수들의합.java
@@ -1,0 +1,19 @@
+package week11;
+
+import java.util.Scanner;
+
+public class BOJ_1789_수들의합 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        long n = sc.nextLong();
+        int count = 0;
+        long i = 1;
+        while(true){
+            if(i*2 >= n) {count++; break;}
+            n -= i++;
+            count++;
+        }
+
+        System.out.println(count);
+    }
+}

--- a/miggule2/week11/BOJ_1946_신입사원.java
+++ b/miggule2/week11/BOJ_1946_신입사원.java
@@ -1,0 +1,34 @@
+package week11;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_1946_신입사원 {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+
+        for(int i = 0; i < t; i++){
+            int n = Integer.parseInt(br.readLine());
+            int cnt = 0;
+
+            int[][] arr = new int[n][2];
+            for(int j = 0; j < n; j++){
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                arr[j][0] = Integer.parseInt(st.nextToken());
+                arr[j][1] = Integer.parseInt(st.nextToken());
+            }
+            Arrays.sort(arr, Comparator.comparingInt(a -> a[0]));
+
+            int min = Integer.MAX_VALUE;
+            for(int j = 0; j < n; j++){
+                if(min > arr[j][1]){
+                    min = arr[j][1];
+                    cnt++;
+                }
+            }
+
+            System.out.println(cnt);
+        }
+    }
+}

--- a/miggule2/week11/BOJ_1946_신입사원_정렬사용x.java
+++ b/miggule2/week11/BOJ_1946_신입사원_정렬사용x.java
@@ -1,0 +1,41 @@
+package week11;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+public class BOJ_1946_신입사원_정렬사용x {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+
+        // 배열 입력받기
+        for(int i = 0; i < t; i++){
+            int n = Integer.parseInt(br.readLine());
+            int cnt = 0;
+
+            // 1차 시험 등수를 index로 해서 배열을 입력받으면 1차 시험 성적대로 정렬된 배열을 얻을 수 있음
+            int[] arr = new int[n+1];
+            for(int j = 1; j <= n; j++){
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                arr[a] = Integer.parseInt(st.nextToken());
+            }
+
+            // 1차 시험 등수대로 정렬된 배열이기에, 배열을 순차적으로 순회하며 이전에 등장한 2차 등수보다 높으면 1차는 못했지만 2차는 더 잘했기에 카운트 할 수 있음.
+            // 즉, 1차 시험 등수대로 정렬된 배열을 순회하며 2차 시험은 오름차순이 돼야한다.
+            int min = Integer.MAX_VALUE;
+            for(int j = 1; j <= n; j++){
+                if(min > arr[j]){
+                    min = arr[j];
+                    cnt++;
+                }
+            }
+
+            System.out.println(cnt);
+        }
+    }
+}


### PR DESCRIPTION
### [백준] 수들의 합 / 실버4 / 30분
*문제의 세부조건을 놓쳐 시간이 지연된 문제
* 제일 마지막 i값의 2배가 되면 값이 중복되기 때문에 제외시켜줘야함.

### [백준] 주유소 / 실버4 / 50분
* 그리디 알고리즘을 이용해서 무조건 후에 나오는 주유소보다 싼 주유소에서 주유를 하면 되는 문제
* 즉 내림차순으로 싼 주유소까지 비용만 지불하고, 이를 반복하면 되는 문제
* 하지만 진짜 말 그대로 뒤에서 거꾸로 순회하며 오름차순으로 계산하려 해서 코드가 조금은 복잡해짐.
* 세부적인 조건을 생각해서 전체적인 틀을 생각하지 못했던 문제.

### [백준] 신입사원 / 실버1 / 30분
* 처음 풀이에서는 이차원 배열을 만들어 2차 시험의 등수를 오름차순으로 만족하는 개수를 구하면 되는 문제라고 생각했고, 그렇게 풀이함.
* __이차원 배열에서 첫 요소 기준으로 정렬하는 코드__
```java
Arrays.sort(arr, Comparator.comparingInt(a -> a[0]));
```
* 두번쨰 풀이(구글링)에서는 그냥 입력받을 때부터 __1차시험의 등수를 index로 2차 시험을 값으로 하는 일차원 배열__ 로 받으면 정렬을 굳이 하지 않아도 되어 ```O(n)```의 복잡도로 풀이할 수 있었음.
* 문제에서 쌍이 되는 값이 주어지고 정렬해야 하는 구조라면 위의 방법을 적극 사용해야겠다.