### PR TITLE
채태영 / 12주차 / 3문제

### DIFF
--- a/tttyoung/week_12/boj_1158_요세푸스문제.py
+++ b/tttyoung/week_12/boj_1158_요세푸스문제.py
@@ -1,0 +1,15 @@
+from collections import deque
+n, k = map(int, input().split())
+dq = deque(i for i in range(1, n+1))
+
+def Josephus(dq, k):
+    result = []
+    while len(dq)>=1: #마지막 한개 숫자 남을때까지
+        dq.rotate(1 - k) #(-) 방향으로 돌려야하기때문에 1-k만큼 rotate한 후
+        result.append(dq[0]) #첫번째값을 result에 추가
+        dq.popleft() #첫번째 값 pop
+
+    return result
+
+print("<", ", ".join(map(str, Josephus(dq, k))), ">", sep = "")
+

--- a/tttyoung/week_12/boj_9184_신나는함수실행.py
+++ b/tttyoung/week_12/boj_9184_신나는함수실행.py
@@ -1,0 +1,24 @@
+memo = {} #메모지에이션
+def w(a, b, c):
+    if (a, b, c) in memo: #이미 메모에 저장된 값이면 메모에서 꺼내서 씀
+        return memo[(a, b, c)]
+
+    elif a <= 0 or b <= 0 or c <= 0:
+        return 1
+
+    elif a > 20 or b > 20 or c > 20:
+        return w(20, 20, 20)
+
+    elif a < b < c:
+        memo[(a, b, c)] = w(a, b, c-1) + w(a, b-1, c-1) - w(a, b-1, c) #점화식, 나온값 메모에 저장
+        return memo[(a, b, c)]
+
+    else:
+        memo[(a, b, c)] = w(a-1, b, c) + w(a-1, b-1, c) + w(a-1, b, c-1) - w(a-1, b-1, c-1) #점화식, 나온값 메모에 저장
+        return memo[(a, b, c)]
+    
+while True:
+    a, b, c = map(int, input().split())
+    if a==-1 and b==-1 and c==-1:
+        break
+    print(f"w({a}, {b}, {c}) = {w(a, b, c)}")

--- a/tttyoung/week_12/boj_9934_완전이진트리.py
+++ b/tttyoung/week_12/boj_9934_완전이진트리.py
@@ -1,0 +1,18 @@
+def recursive_city(citylist, floor, result):
+    mid = len(citylist) // 2 #중앙값이 부모노드이므로 
+    result[floor].append(citylist[mid]) #그 중앙값을 첫층에 추가
+
+    if len(citylist) == 1: #재귀 반복하다가 숫자가 한개가 남을때 재귀 종료
+        return 
+    
+    #재귀 반복할수록 층수는 하나씩 내려감
+    recursive_city(citylist[:mid], floor + 1, result) #mid기준으로 왼쪽값 재귀반복
+    recursive_city(citylist[(mid+1):], floor + 1, result) #mid기준으로 오른쪽값 재귀 반복
+
+k = int(input())
+searchlist = list(map(int, input().split()))
+result = [[] for i in range(k)] #층수에 맞는 빈 리스트 생성
+
+recursive_city(searchlist, 0, result) #0층부터 시작하여 
+for i in range(k):
+    print(" ".join(map(str, result[i])))


### PR DESCRIPTION
### [boj] / 1158_요세푸스문제 / 실버4 / 20분
- 덱을 이용하는 간단한 문제. 
- rotate와 pop의 순서를 생각해봤을때 rotate를 먼저 한 후에 결과리스트에 추가하고 pop을 함.

### [boj] / 9934_완전이진트리 / 실버1 / 1시간반
- 재귀를 이용하는 문제
- 처음에는 리스트 순서대로 어떤 층에 들어갈지 찾는 방식으로 풀려고했으나 그렇게 된다면 계속 층을 바꿔가며 입력을 해줘야함. 
- 리스트 중앙값이 가장 위층 값이라는것을 알아내고 재귀로 그 중앙값을 기준으로 양방향또한 중앙값을 모은것이 해당 층의 숫자임을 파악함.
- 중앙값을 빈 리스트에 저장후 mid를 기준으로 양방향으로 재귀를 사용하여 그 다음층의 숫자들을 저장해줌.
- 탈출조건은 해당 리스트의 숫자가 한개가 되었을때 중앙값은 그 숫자 자체이므로 리스트에 저장 후에 탈출 할 수 있게 해놓음.

### [boj] / 9184_신나는함수실행 / 실버2 / 1시간반
- 이미 주어진 재귀를 이용하는 코드를 dp로 바꿔서 푸는 문제
- DP자체가 어떤 방식으로 이루어지는건지를 몰라서 찾아보면서 답지를 참고함.
- 조건달성시에 점화식을 이용하여 풀어야되는 부분에 DP를 적용하여 memo에 해당 값을 저장함(중복으로 계산하는것을 방지)
- memo에 이미 값이 있을시에는 중복계산 방지를 하여 memo에서 값을 찾아옴.