### PR TITLE
채태영 / 13주차 / 3문제

### DIFF
--- a/tttyoung/week_13/boj_1003_피보나치함수.py
+++ b/tttyoung/week_13/boj_1003_피보나치함수.py
@@ -1,0 +1,27 @@
+#다른방법으로도 풀어보기
+def fibonacci(n, memo):
+    if n == 0:
+        return [0, 1, 0]
+    elif n == 1: 
+        return [1, 0, 1]
+    
+    if memo[n][0] is not None:
+        return memo[n]
+    #memo[n] = fibonacci(n-1, cnt, memo) + fibonacci(n-2, cnt, memo) 원래의 점화식으로 memo에 피보나치 수열값만 저장이 됨 n==0, 1일때 cnt를 더해준다고 해서 memo에서 값을 가져올때 cnt가 저장되는것이 아님.
+    fib1, z1, o1 = fibonacci(n-1, memo)
+    fib2, z2, o2 = fibonacci(n-2, memo)
+
+    memo[n] = [fib1 + fib2, z1 + z2, o1 + o2]
+
+    return memo[n]
+    
+    
+t = int(input())
+
+for _ in range(t):
+    n = int(input())
+    memo = [[None, 0, 0] for _ in range(n+1)]  #현재 cnt값들은 memo에 저장되지않아서 memo에서 값을 가져올때도 cnt값을 같이 가져와줘야하는데 그 과정이 생략되어있음.그치만 정확이 왜 22입력일때 1 2가 나오는지 모르겠음.해결완료. 
+    result = fibonacci(n, memo)
+    print(result[1], result[2])
+    #memo[n][1], memo[n][2]을 출력하려고 했으나 n = 0이나 1일 경우에는 fibonacci함수에서 나오는게 [0, 1, 0] [0, 1, 0]임. 이 경우에 그냥 바로 return한 것이지 memo값을 변경해준것은 아님. 
+    #해결하려면 위 코드처럼 return값에 대한 결과를 출력하거나 n=0 or 1일때 return대신 memo에 저장하도록 해야함.

--- a/tttyoung/week_13/boj_10814_나이순정렬.py
+++ b/tttyoung/week_13/boj_10814_나이순정렬.py
@@ -1,0 +1,10 @@
+num = int(input())
+plist = []
+for i in range(num):
+    plist.append(list(map(str, input().split())))
+    plist[i][0] = int(plist[i][0]) #입력은 str형태로 받았기 때문에 숫자는 int형으로 변환해줌.그러지 않으면 정렬과정에서 문제가 발생함.
+
+plist.sort(key = lambda x:x[0]) #다중리스트나 딕셔너리같이 리스트내에 하나의 객체만 있는것이 아닐때, lambda를 이용하여 원하는 키값에 대한 정렬을 할 수 있음
+
+for j in range(num):
+    print(' '.join(map(str, plist[j])))

--- a/tttyoung/week_13/boj_2003_수들의합2.py
+++ b/tttyoung/week_13/boj_2003_수들의합2.py
@@ -1,0 +1,23 @@
+#다른방법으로도 풀어보기
+n, m = map(int, input().split())
+numlist = list(map(int, input().split()))
+
+def numhap(numlist, m):
+    start = end = count = 0
+    sum = numlist[start]
+    while start <len(numlist) and end < len(numlist):
+        if sum < m:
+            end += 1
+            if end == len(numlist):
+                break
+            sum += numlist[end]
+        elif sum > m:
+            sum -= numlist[start]
+            start += 1
+        else:
+            count += 1
+            sum -= numlist[start]
+            start += 1
+    return count
+
+print(numhap(numlist, m))


### PR DESCRIPTION
### [boj] / 1003_피보나치함수 / 실버3 / 3시간반

- 이번주 문제중 가장 힘들었던 문제. 피보나치수열을 다이나믹프로그래밍을 이용하여 시간초과를 해결해야하는 문제임.
- 메모지에이션을 사용했으며 피보나치수열의 값을 구하는것은 점화식 작성만 하면 되는 작업이라 간단했으나 0과 1이 출력되는 횟수를 저장하는 작업이 힘들었음.
- 처음에는 cnt값이 늘어나지 않길래 확인해보니  memo에cnt값이 저장되지 않고 피보나치값만 저장되는것을 알게됨. 그러나 우리는cnt값이 필요하기 때문에 어떤 방식으로 저장해서 출력되게해야하는지를 고민함.
- memo를 인자가 3개인 이중리스트로 만들고 memo에도 cnt값이 저장되게 하기 위해서 밑 코드처럼 피보나치를 바로 더하는것이 아닌, 각 인자를 각각 더하게 해주고 그 값을 memo에 합쳐서 저장함.
 ```    
    fib1, z1, o1 = fibonacci(n-1, memo)
    fib2, z2, o2 = fibonacci(n-2, memo)

    memo[n] = [fib1 + fib2, z1 + z2, o1 + o2]
```

- memo[n][1], memo[n][2]을 출력하려고 했으나 n = 0이나 1일 경우에는 fibonacci함수에서 나오는게 [0, 1, 0] [0, 1, 0]임. 이 경우에 그냥 바로 return한 것이지 memo값을 변경해준것은 아님. 현재 코드처럼 return값에 대한 결과를 출력하거나 n=0 or 1일때 return대신 memo에 저장하도록 해야함.

### [boj] / 2003_수들의합2 / 실버4 / 40분

- 지난주에 풀었던 boj_1806_부분합 문제와 같은 방법으로 풀었음. 
- 투포인터를 이용해서 index0지점에서 start end를 모두 시작하고 sum은 start값으로 시작했음. sum와 m의 값을 비교하면서 값을 더하거나 뺐음. 
- sum<m일때 만약 end가 index마지막값이라면 end가 +=1 되면서 index를 초과하기 때문에 바로 밑에 end가 초과했을 때 break하도록 만들어줌. 

### [boj] / 10814_나이순정렬 / 실버5 / 30분

- 예전에 풀었다가 실패한 문제. 입력으로 나이와 이름이 주어지는데 나이순으로 정렬하되 같은 나이일 경우에는 먼저 입력된 순서로 정렬하는 문제임.
- 아래 코드와 같이 lambda를 이용하여 나이만으로 정렬하게 함. 이렇게 정렬하면 이름은 어차피 입력된 순서로 놓이게 되기 때문에 추가적인 구현을 해줄 필요가 없음.
```
 plist.sort(key = lambda x:x[0])
```