### PR TITLE
채태영 / 16주차 / 3문제

### DIFF
--- a/tttyoung/week_16/boj_11726_2xn타일링_dp.py
+++ b/tttyoung/week_16/boj_11726_2xn타일링_dp.py
@@ -1,0 +1,13 @@
+def tiling(n):
+    memo = [0] * (n+2) #memo[2]를 밑에서 따로 만들어주기때문에 1이 들어갔을때 n+1의 크기로 하면 인덱스 에러 발생, 
+    #1을 예외처리로 두거나 memo리스트의 범위를 늘려주면 됨
+    memo[1] = 1
+    memo[2] = 2
+    for i in range(3, n+1):
+        memo[i] = (memo[i-1] + memo[i-2]) %10007 #그림 그려보면 i-1에는 가로 1칸짜리, i-2에는 가로 2칸짜리를 추가하면 된다. 
+    return memo[n]
+
+n = int(input())
+print(tiling(n))
+
+

--- a/tttyoung/week_16/boj_1463_1로만들기_dp.py
+++ b/tttyoung/week_16/boj_1463_1로만들기_dp.py
@@ -1,0 +1,15 @@
+def make_one(n):
+    memo = [-1] * (n+2)
+    memo[1] = 0
+    for i in range(2, n+1): #2,3은 기본값으로 주고 for문을 4부터 시작하려고 했지만 입력으로 1이 들아오면 indexerror가 발생.
+        memo[i] = memo[i-1] + 1
+        if i % 3 == 0: #3으로 나눠진다면 3으로 나눈 값과 i-1의 값 중 더 작은 값으로 넘어감.
+            memo[i] = min(memo[i//3], memo[i]-1) + 1
+        if i % 2 == 0: #2로 나눠진다면 2로 나눈값과 i-1의 값 중 더 작은 값으로 넘어감.
+            #3으로 나눈 값보다 2로 나눈 값의 리턴값이 큰 경우를 고려하여 elif 대신 if를 써야함.
+            memo[i] = min(memo[i//2], memo[i]-1) + 1 
+    return memo[n]
+
+N = int(input())
+print(make_one(N))
+

--- a/tttyoung/week_16/boj_1966_프린터큐_덱.py
+++ b/tttyoung/week_16/boj_1966_프린터큐_덱.py
@@ -1,0 +1,28 @@
+from collections import deque
+
+def printqu(dq, m):
+    target = dq[m][0] #타겟문서의 고정 인덱스, 추적하기위해 고정인 값
+    count = 0
+
+    while True:
+        if len(dq) == 1:
+            count += 1
+            break
+        elif dq[0][1] < max(dq[i][1] for i in range(1, len(dq))):
+            dq.rotate(-1) #맨 앞 문서를 뒤로 보냄
+        else:
+            if target == dq[0][0]: #타겟문서가 첫값이면 탈출
+                count += 1
+                break
+            else:
+                dq.popleft() #아니라면 pop
+                count+=1
+    return count
+
+t = int(input()) #testcase수
+for i in range(t):
+    n, m = map(int, input().split()) #문서의개수, 타겟문서의 초기 인덱스
+    #문서의 중요도를 리스트로 받고, enumerate를 이용하여 입력받은 문서의 인덱스를 남겨줌.
+    #문서의 중요도만 입력 받기때문에 중요도가 같은 경우 문서를 구분하기 위함.
+    dq = deque([i, v] for i, v in enumerate(list(map(int, input().split()))))
+    print(printqu(dq, m))


### PR DESCRIPTION
### [boj] 1966_프린터큐 / 실버3 / 2시간

- 덱을 이용하여 문서의 중요도에 따라서 덱을 rotate하며 원하는 값이 되었을때 출력해야하는 문제. 
- 입력되는것이 문서의 중요도이기 때문에 문서를 구분해주기 위해서 enumerate를 사용하여 index를 매겨줌.
- 추적을 위한 고정 인덱스값 target을 바탕으로 덱을 중요도별로 rotate하면서 덱의 첫값이 타겟문서면 count를 하고 break, 아니라면 pop후 count를 하고 while문을 반복하는 형태로 코드를 짬. 
- rotate되면서 실제 index는 바뀌기 때문에 고정 index를 추적해서 타겟 문서를 찾아야한다는것을 생각하기 까다로웠음.

### [boj] 1463_1로만들기 / 실버3 / 1시간반
- -1, 나누기2, 나누기3을 통해 1로 만드는 과정을 출력해야하는 문제. dp바텀업 알고리즘으로 풂.
- dp로 풀기 위해 전체적인 패턴을 찾아 점화식으로 풀려고 했으나 이 과정보다는 min을 이용하여 다른 방법과 비교하여 작은 값을 넣는 방법으로 바꿔서 풂.
- 초기 점화식으로 dp[i-1]+1을 사용하여 기본값을 -1방법으로 해놓고, if문을 통해 3으로 나눴을때와 2로 나눴을때를 구분하여 min함수를 사용함. 
- 2로 나누는 if문을 elif를 사용하여 풀었으나 틀림. 2와 3으로 동시에 나눠지는 값중 3으로 나눈값보다 2로 나눈 값이 더 작은 경우를 고려하지 않았음. 모든 if문을 통과 가능하도록 둘다 if를 사용함.
- dp에서 바텀업 방식을 사용할때 memo[1]와 같이 기본 값을 깔아두고 시작하는 경우가 많은데 이때 for문에 들어가는 값에 따라 indexerror가 발생 할 수 있으므로 범위조정에 조심해야함.

### [boj] 11726_2xn타일링 / 실버3 / 30분
- dp 바텀업 알고리즘을 사용하는 간단한 문제. 
- 그림을 그려보며 패턴을 찾아보다가 memo[i] = memo[i-1] + memo[i-2] 라는 간단한 피보나치 수열의 점화식을 사용한다는것을 발견.
- 이 문제에서는 memo[1], [2]를 미리 만들어두고 for문을 통해 나머지를 채워줌. memo리스트의 크기를 처음에는 n+1로 했는데 입력으로 1이 들어오게 된다면 memo[2]가 생성될 공간이 없음. 미리 만들어두는 값을 고려하여 memo 리스트의 크기를 만들어야함. 