### PR TITLE
채태영 / 17주차 / 3문제

### DIFF
--- a/tttyoung/week_17/boj_1149_rgb거리_dp.py
+++ b/tttyoung/week_17/boj_1149_rgb거리_dp.py
@@ -1,0 +1,12 @@
+def rgb(n, rgb_list):
+    dp = [[0, 0, 0] for _ in range(n)]
+    dp[0] = rgb_list[0] #for문 돌리기 위해 초기값 설정
+    for i in range(1, n): #누적합을 이용하여 dp테이블 구현 
+        dp[i][0] = min(dp[i-1][1], dp[i-1][2]) + rgb_list[i][0] #빨강일때 이때까지의 최솟값+현재값
+        dp[i][1] = min(dp[i-1][0], dp[i-1][2]) + rgb_list[i][1] #초록일때 이때까지의 최솟값+현재값
+        dp[i][2] = min(dp[i-1][0], dp[i-1][1]) + rgb_list[i][2] #파랑일때 이때까지의 최솟값+현재값
+    return min(dp[n-1]) #마지막 3가지색의 경우 중 가장 작은 경우를 출력
+
+n = int(input())
+rgb_list = [list(map(int, input().split())) for _ in range(n)]
+print(rgb(n, rgb_list))

--- a/tttyoung/week_17/boj_1932_정수삼각형_dp.py
+++ b/tttyoung/week_17/boj_1932_정수삼각형_dp.py
@@ -1,0 +1,11 @@
+def int_tri(n, tri_list):
+    dp = [[0]*(i+1)for i in range(n)]
+    dp[n-1] = tri_list[n-1]
+    for i in range(n-2,-1,-1):#입력된 정수리스트를 거꾸로 시작하여 마지막에 가장 윗값이 오도록 for문 구현
+        for j in range(i+1):
+            dp[i][j] = max(dp[i+1][j], dp[i+1][j+1]) + tri_list[i][j]#해당칸의 값은 다음줄 같은위치와 다음줄 다음 위치값중 큰 값
+    return dp[0][0]
+
+n = int(input())
+tri_list = [list(map(int, input().split())) for _ in range(n)]
+print(int_tri(n, tri_list))

--- a/tttyoung/week_17/boj_2579_계단오르기_dp.py
+++ b/tttyoung/week_17/boj_2579_계단오르기_dp.py
@@ -1,0 +1,16 @@
+def stair(n, s_list):
+    dp = [0] * (n+1)
+    dp[0] = s_list[0] #계단이 2칸 이하일 경우는 고정값
+    if n>1:
+        dp[1] = dp[0] + s_list[1]
+    for i in range(2, n):
+        dp[i] = max(dp[i-3] + s_list[i-1], dp[i-2]) + s_list[i] 
+        #특정칸으로 가기 위한 과정은 n-2에서 2칸을 점프하거나 n-1에서 1칸 점프해서 오는 경우임.
+        #n-1에서 1칸 점프에서 오기 위해서는 그 전에 위치했던 칸이 n-3이여야함.(3칸을 연속으로 점프할 수는 없기때문)
+        #점화식을 구할때 경우가 나눠지는것을 분기점으로 점화식을 생각해야함함
+    return dp[n-1]
+
+n = int(input())
+s_list = [int(input()) for _ in range(n)]
+print(stair(n, s_list))
+    


### PR DESCRIPTION
### [boj] 2579_계단오르기 / 실버3 / 1시간
- dp를 사용하는 문제로 최대 횟수를 구하는것이 아닌 계단에 있는 점수의 최대합을 구해야함.
- 점수의 최대합이므로 점수의 누적합을 구하면서 점프를 하면 점프한 위치의 점수를 누적합에 더해줌.
- 처음에 풀때는 연속된 3칸을 밟을 수 없다는 조건 때문에 for문을 만들면서 예외처리로 if문을 만들어서 처리하려고 했으나 복잡하여 실패함.
- dp[i]를 구하기 위해서 점프하기 직전 위치가 어딘지가 중요함. i-2에서 2칸을 점프하거나 i-1에서 1칸을 점프하는 경우로 나눠짐. i-1에서 점프를 하는 경우에는 제약조건이 생기는데 i-1직전의 점프는 무조건 i-3에서 이뤄져야함.(연속된 3칸을 밟을 수 없기 때문)
```
for i in range(2, n): 
        dp[i] = max(dp[i-3] + s_list[i-1], dp[i-2]) + s_list[i]
```
- 2가지 경우로 나뉘는 곳을 분기점으로 생각하여 점화식을 작성함.

### [boj] 1932_정수삼각형 / 실버1 / 50분
- 트리같이 생긴 숫자배열에서 가장 처음 입력값부터 가장 마지막 입력줄까지 연결한 것중 숫자 합이 가장 큰 경우를 찾는 dp문제.
- 바텁업 방식을 생각하여 마지막 입력부터 하나씩 위로 올라가며 더해나가는 방법으로 풂.
```
for i in range(n-2,-1,-1):#입력된 정수리스트를 거꾸로 시작하여 마지막에 가장 윗값이 오도록 for문 구현
        for j in range(i+1):
            dp[i][j] = max(dp[i+1][j], dp[i+1][j+1]) + tri_list[i][j]#해당칸의 값은 다음줄 같은위치와 다음줄 다음 위치값중 큰 값
```
- 이 문제를 풀때는 어떤 위치의 값을 더해줄지를 생각하는것과 밑에서 위인 역순으로 누적합을 생각해내는것이 핵심임.

### [boj] 1149_rgb거리 / 실버1 / 40분
- 전부터 풀어보려 했으나 점화식을 생각해내지 못해서 실패했던 문제.
- 경우의 수가 3가지가 생기는데 이 3가지 경우의수가 한집씩 넘어갈때마다 계속 생겨나가기 때문에 어떤 방식으로 최솟값을 구해야할지 생각하는것이 어려워서 다른 사람들 풀이를 약간 참고하였음.
- 재귀를 풀듯이 특정 해당지점을 정해서 생각해놓고 이 지점의 값이 나오기 위해서는 전이나 후에 어떤 영향을 받아 점화식이 생길 수 있을지 고민해야함. 이 문제의 경우에는 rgb 3가지 경우의 점화식을 각각 만들고 마지막 값에서 rgb각각의 누적합중 최솟값을 구하는 형태로 풀었음.
- 이웃한 집과는 색이 겹치면 안되기때문에 원래는 양 끝쪽을 제외한 집들이면 i-1집과 i+1집의 색을 신경써야하지만 for문을 돌리면서 어차피 다음집도 같은 조건을 가지기 때문에 i-1집과 색이 겹치지만 않게 하면 된다. 
