### PR TITLE
채태영 / 18주차 / 3문제

### DIFF
--- a/tttyoung/week_18/boj_11047_동전0_그리디.py
+++ b/tttyoung/week_18/boj_11047_동전0_그리디.py
@@ -1,0 +1,17 @@
+#동전 단위 리스트가 주어지고 k원을 만드는데 드는 동전 최솟값 구하기
+#큰 단위부터 for문을 돌리며 k보다 작은 단위가 나온순간부터 계산 시작 -> 순간의 최선의 선택으로 최솟값을 구하기 (그리디)
+
+def min_coin(n, k, coinlist):
+    count = 0
+    for i in range(n-1, -1, -1): #큰단위부터 비교하기 위해 for문 거꾸로 실행
+        if k == 0: #금액 충족시 for문 탈출출
+            break
+        if coinlist[i]<=k: #단위가 금액보다 작은경우 몫을 count에 더해주고 금액을 나머지 금액으로 대체함.
+            count += k//coinlist[i]
+            k %= coinlist[i]
+    return count
+
+N, K = map(int, input().split())
+coin_list = [int(input()) for _ in range(N)]
+print(min_coin(N, K, coin_list))
+

--- a/tttyoung/week_18/boj_1715_카드정렬하기_그리디_실패.py
+++ b/tttyoung/week_18/boj_1715_카드정렬하기_그리디_실패.py
@@ -1,0 +1,20 @@
+from collections import deque
+#입력받은 카드 수 리스트를 정렬하여 앞에 2개를 묶어서 합침. 이때 합한 수는 result에 누적
+#앞의 2개의 카드묶음을 더한 후 index 1에 대입하고 index 0을 popleft하여 지움.
+#실패 사유: 시간초과 / 한번 합칠때마다 덱을 정렬해야하므로 N이 100,000일때 시간복잡도가 적어도 100,000log(100,000)
+
+def sort_card(cardnum):
+    result = 0
+    cardnum = deque(sorted(cardnum)) #초기 덱 정렬렬
+    while len(cardnum)>1: #카드 묶음이 1개가 남을때까지
+        if cardnum[0] > cardnum[1]: #시간초과 해결하려고 모든 경우에 정렬이 아닌 index 0 이 index 1보다 큰 경우에만 정렬을 시도도
+            cardnum = deque(sorted(cardnum))
+        #카드 묶음 합친후, result 갱신, popleft하여 합쳐진 카드리스트를 만듦
+        cardnum[1] = cardnum[0] + cardnum[1] 
+        result += cardnum[1]
+        cardnum.popleft()
+    return result
+
+N = int(input())
+card_num = deque([int(input()) for _ in range(N)])
+print(sort_card(card_num))

--- a/tttyoung/week_18/boj_1931_회의실배정_그리디.py
+++ b/tttyoung/week_18/boj_1931_회의실배정_그리디.py
@@ -1,0 +1,18 @@
+#배정받은 회의시간 리스트를 참고하여 가능한 최대 회의 수 구하기
+
+def max_meeting(N, meetinglist):
+    #starttime = -1
+    endtime = -1
+    count = 0
+    for meeting in meetinglist:#문제에서는 회의가 아예 중복인경우 각각 계산해주는듯듯
+        if meeting[0] >= endtime: #and meeting[1] != starttime 이거는 왜 틀린거지? 4 (0 0) (0 0) (0 1) (1 1)은 3 나와야하는거 아님?
+            count+=1
+            endtime = meeting[1]
+            #starttime = meeting[0]
+    return count
+    
+N = int(input())
+meetinglist = [list(map(int, input().split())) for _ in range(N)]
+meetinglist.sort(key=lambda x: (x[1], x[0])) #입력받은 회의시간들을 1순위:끝나는시간, 2순위:시작시간으로 정렬함
+#2순위까지 정렬해야 (3 3) (4 4) (1 4) (3 4) 이런 경우 (3 3) 다음에 (3 4)가 나옴. 정렬 안하면 (4 4) 나옴옴
+print(max_meeting(N, meetinglist))


### PR DESCRIPTION
### 그리디 알고리즘
* 각 단계에서 최적의 선택을 하여 최종적인 답으로 도달하게 만드는 알고리즘.

### [boj] 11047_동전0 / 실버4 / 30분
* 동전단위를 입력으로 받아 원하는 K원을 만드는데 드는 동전의 최솟값 구하는 문제
* 단위가 큰것부터 차례로 for문을 돌면서 K원보다 작은 값이 될때 계산시작.
* 큰 단위부터 계산을 하게 되면 동전수가 최솟값이 나오기 때문에 각 단계에서의 최적의 선택을 하는 그디리 알고리즘 사용
* for문을 돌면서 k원을 만족하게 된다면 for문 탈출하여 추가적인 계산을 없앰.

### [boj] 1931_회의실배정 / 골드5 / 2시간
* 배정받은 회의시간 리스트를 참고하여 가능한 최대 회의 수 구하기
* 문제의 조건이 애매하여 시간이 오래 걸린 문제. 문제 자체의 알고리즘 구현은 생각보다 어렵지 않음.
* 각 단계에서의 최선의 선택을 하기 위해 회의 리스트를 정렬함.
 정렬기준은 우선순위1: index 1 (끝나는시간), 우선순위2: index 0 (시작시간)으로 설정. 
 정렬 이유: 최대의 회의를 만들기 위해서는 다음 회의의 시작시간이 현재 회의의 끝나는 시간보다 크거나 같은것중 회의시간이 가장 작아야하기 때문.
* for문 구현시 정렬된 meetinglist를 돌면서 시작시간이 전 회의의 끝나는 시간보다 크거나 같으면 최선의 회의로 선택함. 이때 endtime을 새로 갱신해주어야 다음 회의에서 전 회의와 비교가능.
```
 for meeting in meetinglist:
        if meeting[0] >= endtime:
            count+=1
            endtime = meeting[1]
```

* 그러나 문제에 회의가 아예 중복인 경우에 대해서는 설명이 없음. ex) (0 0) (0 0) (0 1) (1 1) 인 경우에는 정답이 4가 나오게 되는데 아예 같은 시간에 있는 회의면 하나의 회의만 가능하지 않나?라는 의문때문에 이를 구현하다가 계속 틀림. 문제 오류.

### [boj] 1715_카드정렬하기_실패 / 골드4 / 1시간30분
* 단순 그리디와 덱을 이용하여 풀려다 시간초과로 실패한 문제, 찾아보니 heapq를 사용해야 시간초과를 피할 수 있다고 함. 다음번에 heapq를 공부하면 다시 풀어볼 예정.
* 처음 문제 이해가 어려웠지만 카드묶음에서 가장 작은 2개를 합쳐 새로운 리스트를 만들고 카드묶음이 1개가 남을때까지 반복. 이때의 누적합을 구해야함.
* 가장 작은 2개를 찾아야하므로 정렬을 하여 2개를 합친 후 popleft를 하여 리스트 항목수를 줄여나갔음. 
* 주어진 testcase는 만족하지만 시간초과발생.
 시간초과 이유: 덱에서 가장 작은 2개를 합칠때마다 sort를 이용하여 정렬해야함. 최대 카드묶음 수는 100,000이므로 sort만 생각해봐도 적어도 100,000log(100,000)의 최대 시간복잡도가 발생함.


