### PR TITLE
채태영 / 19주차 / 3문제

### DIFF
--- a/tttyoung/week_19/boj_11866_요세푸스문제0.py
+++ b/tttyoung/week_19/boj_11866_요세푸스문제0.py
@@ -1,0 +1,16 @@
+from collections import deque
+def yo(dq, k):
+    result = []
+    while(dq): #dq에 값이 남아있는동안 rotate를 통해 k번째값을 맨 앞으로 위치시키고 popleft를 통해 제거
+        dq.rotate(-k+1)
+        result.append(dq[0])
+        dq.popleft()
+    return result
+
+n, k = map(int, input().split())
+dq = deque()
+for i in range(n):
+    dq.append(i + 1)
+
+print(f"<{', '.join(map(str, yo(dq, k)))}>") #f-string을 사용하여 출력, join을 사용하여 리스트내부값만 출력할 수 있도록 함
+

--- a/tttyoung/week_19/boj_1874_스택수열.py
+++ b/tttyoung/week_19/boj_1874_스택수열.py
@@ -1,0 +1,21 @@
+n = int(input())
+
+new_st = []
+result = []
+p = 0 #오름차순으로 하나씩 push가능하기 때문에 해당값을 저장할 변수
+
+for _ in range(n):
+    num = int(input())
+    while p < num: #수열준비과정, push를 해서 p값 조정 및 pop을 통해 만들 수열의 기반수열을 만듦.+
+        p+=1
+        new_st.append(p)
+        result.append("+")
+    if new_st[-1] == num: #pop하는 과정, pop을 통해 우리가 원하는 해당 수열을 result에 저장함. 
+        new_st.pop()
+        result.append("-")
+    else: #불가능한 수열, 만약 pop해야되는 값이 new_st의 마지막값이 아닌 중간값이라면 pop을 통해 수열만들기 불가능.
+        result.clear()
+        result.append("NO")
+        break
+
+print('\n'.join(result))

--- a/tttyoung/week_19/boj_2740_행렬곱셈.py
+++ b/tttyoung/week_19/boj_2740_행렬곱셈.py
@@ -1,0 +1,24 @@
+N, M = map(int, input().split())
+A = [list(map(int, input().split())) for _ in range(N)]
+
+M, K = map(int, input().split())
+B = [list(map(int, input().split())) for _ in range(M)]
+
+C = [[0 for _ in range(K)] for _ in range(N)] #result행렬 0으로 세팅
+
+#i, j가 고정일때 k값을 변동하면서 그 합을 누적하여 C[i][j]를 구함.
+for i in range(N):
+    for j in range(K):
+        for k in range(M):
+            C[i][j] += A[i][k] *B[k][j]
+            
+#캐시 친화적 코드
+#kij순서로 for문을 돌리면서 행마다 한번식 곱하여 누적하는 방식으로 기존의 ijk와 달리 C[i][j]를 하나씩 한번에 완성시키는것이 아닌, k for문이 돌때까지 행으로 분산하여 계산해주고 누적합을 통해 C를 완성시킴.
+for k in range(M):
+    for i in range(N):
+        r = A[i][k]
+        for j in range(K):
+            C[i][j] += r *B[k][j]
+
+for p in range(N):
+    print(*C[p])


### PR DESCRIPTION
### [boj] 2740_행렬곱셈 / 실버5 / 1시간

- 단순 행렬곱셈 구현문제
- 3중 for문을 통해 C[i][j] += A[i][k] * B[k][j]를 구현해야하지만 계산을 수식화하는 과정을 이해하는데 시간이 걸림.
- 시스템소프트웨어에서 배웠던거를 사용하여 cache친화적으로 ijk코드가 아닌 kij코드를 통해 행연산을 하여 cache메모리를 최소한으로 사용하게끔 작성하였음.
```
for k in range(M):
    for i in range(N):
        r = A[i][k]
        for j in range(K):
            C[i][j] += r *B[k][j]
```

### [boj] 1874_스택수열 / 실버2 / 1시간 

- 주어진 수열을 만들기 위해 오름차순으로 숫자를받아 push와 pop을 통해 해당 수열로 만드는 문제
- 처음에는 마지막으로 push한 값인 p보다 입력받은 숫자가 작을대만 pop을 해야하는것으로 착각하여 구현에 어려움을 느낌.
- push는 오름차순으로 숫자를 받아 기반수열을 준비하는과정, pop은 해당 숫자가 마지막 숫자와 같으면 pop을 하여 우리가 원하는 수열의값과 일치되도록 만들어주는 과정임.
- push과정에서 처음에는 for문을 사용하려 했으나 p<num이라는 조건을 통해 반복을 효육적으로 하기 위해서 while문을 사용
- p+=1을 반복문 마지막에 적고 p<=num조건을 사용하여 구현 가능하지만 이런 경우에는 p값이 다음으로 사용할 p값으로 저장되기에 직관적인 이해를 위해서 p+=1을 반복문 처음에 적고 조건을 p<num으로 하여 사용한 값까지만 p를 저장하도록 구현함
```
    while p < num: #수열준비과정, push를 해서 p값 조정 및 pop을 통해 만들 수열의 기반수열을 만듦.
        p+=1
        new_st.append(p)
        result.append("+")
```
- pop은 리스트의 마지막값을 빼는 작업이기 때문에 만약 pop을 해야하는 값이 new_st의 중간값이라면 해당 수열 만들기 불가능으로 NO를 출력하도록 else조건문을 사용함.

### [boj] 11866_요세푸스문제0 / 실버4 / 15분

- 전에 풀었던 요세푸스 문제와 알고리즘적으로는 같은 문제.
- deque를 기반으로 rotate를 사용하여 k번째 사람이 dq 맨 앞으로 오도록 위치 조정
- result에 맨 앞 값을 저장 후 popleft를 사용하여 맨 앞 사람을 제거
- f-string을 사용하여 문자열 출력을 효율적으로 만들었으며, join을 통해 리스트 내부 값을 ', '를 기준으로 분리시켜 리스트에서 뺌.
```
print(f"<{', '.join(map(str, yo(dq, k)))}>")
```