### PR TITLE
채태영 / 21주차 / 3문제

### DIFF
--- a/tttyoung/week_21/boj_1010_다리놓기.py
+++ b/tttyoung/week_21/boj_1010_다리놓기.py
@@ -1,0 +1,13 @@
+def factorial(x): #팩토리얼 계산함수
+    f = 1
+    for i in range(x):
+        f *= i+1
+    return f
+
+def bridge(n, m): #점화실 계산함수
+    return factorial(m) // (factorial(n) * factorial(m-n))
+
+t = int(input())
+for i in range(t):
+    n, m = map(int, input().split())   
+    print(bridge(n, m))

--- a/tttyoung/week_21/boj_11727_2x2타일링2.py
+++ b/tttyoung/week_21/boj_11727_2x2타일링2.py
@@ -1,0 +1,13 @@
+def tiling(n):
+    dp = [0 for _ in range(n+2)]
+    dp[1] = 1
+
+    for i in range(2, n+1):
+        if i%2 == 0: #홀수 짝수 경우를 나눠서 점화식 계산
+            dp[i] = dp[i-1]*2 + 1
+        else:
+            dp[i] = dp[i-1]*2 - 1
+    return dp[n]
+
+n = int(input())
+print(tiling(n)%10007)

--- a/tttyoung/week_21/boj_9461_파도반수열.py
+++ b/tttyoung/week_21/boj_9461_파도반수열.py
@@ -1,0 +1,14 @@
+def tri_sequence(n):
+    dp = [0] * max(n, 5) #n과 5중 더 큰 값을 선택하여 리스트의 크기를 결정함. 리스트의 크기는 무조건 5이상이 되어야하기 때문.  
+    dp[0] = dp[1] = dp[2] = 1
+    dp[3] = dp[4] = 2
+    
+    for i in range(5, n):
+        dp[i] = dp[i-1] + dp[i-5]
+    
+    return dp[n-1] #입력 n은 index + 1이기 때문에 n-1번째 숫자를 구함
+
+t = int(input())
+for _ in range(t):
+    n = int(input())
+    print(tri_sequence(n))


### PR DESCRIPTION
### 점화식 위주의 문제풀이 

### [boj] / 1010_다리놓기 / 실버5 / 40분

- 원래 dp로 풀려고 하였으나 간단한 수식으로 끝나는 문제라 그냥 풀었음.
- n이 m보다 항상 작거나 같기 때문에 우측 m개의 포인트에서 n개의 포인트를 순서와 상관없이 뽑는 경우의수 조합을 통해 구함. 어차피 m개중 n개를 뽑은 경우 순서는 무조건 오름차순으로 고정되기 때문에 신경쓸 필요가 없음.
- 팩토리얼 계산함수와 점화식 계산함수를 각각 만듦.

### [boj] / 9461_파도반수열 / 실버3 / 30분

- 간단한 점화식문제로 그림을 그려보면 규칙을 찾을 수 있음.
- `dp[i] = dp[i-1] + dp[i-5]` 라는 점화식을 구하면 되지만 초기값 5개를 고정으로 놓고 풀어야함.
- 바텀업 방식의 dp로 풀었으나 계속 리스트 범위 벗어나는 에러가 발생하여 초기 리스트 크기 수정 및 for문의 범위 수정함. 
- `dp = [0] * max(n, 5)` 로 초기 리스트 크기를 설정함. 5보다 작은 숫자가 들어온다면 최소한 초기값 5의 크기는 만들어주고 5보다 크면 그에 맞는 리스트를 생성하도록 하여 초기값이 고정으로 들어가도록 하였음.

### [boj] / 11727_2x2타일링2 / 실버3 / 20분

- 전에 풀었던 11726_2x2타일링 문제와 유사한 문제로 2x2짜리 타일이 추가되는 문제.
- 따로 문제의 규칙을 찾기보다는 그림을 그려 결과값의 패턴을 유추하여 코드를 작성함.
- 짝수일때와 홀수일때의 경우를 나눠서 점화식을 만듦.