### PR TITLE
김진우 / 20주차 / 3문제

### DIFF
--- a/maureen272/week20/BOJ-1003.py
+++ b/maureen272/week20/BOJ-1003.py
@@ -1,0 +1,19 @@
+# 백준 1003 - 피보나치 함수
+T = int(input())
+cases = [int(input()) for _ in range(T)]
+
+# 최대 N은 40(문제에서 주어짐)
+dp = [[0, 0] for _ in range(41)]
+
+# 초기 조건
+dp[0] = [1, 0]  # fibonacci(0): 0이 1번, 1이 0번 출력
+dp[1] = [0, 1]  # fibonacci(1): 0이 0번, 1이 1번 출력
+
+# dp를 이용하여 피보나치 함수의 호출 횟수 계산
+for i in range(2, 41):
+    dp[i][0] = dp[i - 1][0] + dp[i - 2][0] # 0의 호출 횟수
+    dp[i][1] = dp[i - 1][1] + dp[i - 2][1] # 1의 호출 횟수
+
+# 각 테스트케이스에 대해 출력
+for n in cases:
+    print(dp[n][0], dp[n][1])

--- a/maureen272/week20/Leetcode-147-InsertionSortList.py
+++ b/maureen272/week20/Leetcode-147-InsertionSortList.py
@@ -1,0 +1,23 @@
+# Definition for singly-linked list.
+class ListNode(object):
+    def __init__(self, val=0, next=None):
+        self.val = val
+        self.next = next
+        
+class Solution(object):
+    def insertionSortList(self, head):
+        """
+        :type head: ListNode
+        :rtype: ListNode
+        """
+        
+        cur = parent = ListNode(None)
+        while head:
+            while cur.next and cur.next.val < head.val:
+                cur = cur.next
+                
+            cur.next, head.next, head = head, cur.next, head.next
+            
+            cur = parent
+            
+        return cur.next

--- a/maureen272/week20/Leetcode-179-LargestNumber.py
+++ b/maureen272/week20/Leetcode-179-LargestNumber.py
@@ -1,0 +1,28 @@
+from functools import cmp_to_key
+
+class Solution(object):
+    def largestNumber(self, nums):
+        """
+        :type nums: List[int]
+        :rtype: str
+        """
+        # 비교 함수 정의
+        # 두 숫자 x, y를 문자열로 변환하여 x+y와 y+x을 비교
+        def compare(x, y):
+            if x + y > y + x: # x가 앞에 오는 것이 더 크면 -1
+                return -1
+            elif x + y < y + x: # y가 앞에 오는 것이 더 크면 1
+                return 1
+            else: # 같으면 0
+                return 0
+        
+        # 숫자를 문자열로 변환
+        nums_str = list(map(str, nums))
+        # 정렬
+        nums_str.sort(key=cmp_to_key(compare))
+        
+        # "0000..." 같은 경우 "0"으로
+        if nums_str[0] == '0':
+            return '0'
+        
+        return ''.join(nums_str)


### PR DESCRIPTION
# [Leetcode] Insertion Sort List / medium / 35min
- 연결 리스트를 삽입 정렬로 정렬 해야하는 문제
- 삽입 정렬의 경우 정렬을 해야 할 대상과 정렬을 끝난 대상 이렇게 두 개로 나눠서 진행해야하는데 head를 정렬을 해야하는 대상을 가리키는 포인터로, cur을 정렬을 끝난 대상으로 나타냄
- head를  cur과 비교하면서 더 작으면 cur.next를 이용하여 cur 다음에 삽입될 위치를 찾아 cur 에 추가하는 방식으로 코드를 구현함
``` 
while cur.next and cur.next.val < head.val:
          cur = cur.next
          cur.next, head.next, head = head, cur.next, head.next
``` 
- 문제를 푼 이후에 다른 방법으로 찾는 풀이를 찾아보니 이렇게 삽입 정렬 정석대로 푸는건 타임 아웃으로 처리될 만큼 시간이 오래 걸리는 방법이라 `cur=parent`앞에 
```
if head and cur.val > head.val: 
         cur = parent
``` 
의 조건을 추가해주면 매번 가장 작은 값부터 차례대로 크기를 비교하지 않아도 되어서 시간이 줄어진다고함

# [Leetcode ] Largest Number / medium / 35min
- 항목들을 조합하여 만들 수 있는 가장 큰 수를 출력하는 문제로 리스트 안의 숫자를 문자열로 바꾼 뒤 이를 더해서 비교하면 쉽게 문제를 해결할 수 있었음
- 처음에는 swap함수를 써서 문제를 해결하려고 했는데 내 의도와는 다르게 자꾸 출력이 나와서 그냥 조건문 3개로 case를 지정해주었음
- 그럼에도 처음에 제출했을 때 통과하지 못한 테케가 있었는데 0000과 같은것을 0으로 바꿔주는 예외처리를 해주고 나니 통과됨
```
if nums_str[0] == '0':
        return '0'
```

# [BOJ] 피보나치함수 / silver3 / 25min
- 재귀를 사용하면 간단하게 문제를 해결할 수 있지만 그렇게되면 같은 값을 여러번 계산하게 되어 중복호출이 많아져 시간복잡도가 O(2^n)이 됨
- 그렇기 때문에 탑다운 방식이 아닌 바텀업 방식을 사용해서 이전 결과를 재사용하는 DP를 통해 문제를 해결함
- 