### PR TITLE
채태영 / 22주차 / 3문제

### DIFF
--- a/tttyoung/week_22/boj_11279_최대힙.py
+++ b/tttyoung/week_22/boj_11279_최대힙.py
@@ -1,4 +1,4 @@
-import heapq as hq 
+import heapq as hq #heap 모듈사용
 import sys
 input = sys.stdin.readline
 
@@ -10,7 +10,7 @@ for i in range(n):
     if x == 0:
         if len(heap) == 0:
             print(0)
-        else:
+        else: #변환된 최댓값을 다시 원래 형태로 변환
             print(-hq.heappop(heap)) #추출할때는 앞에 다시 -를 붙임
-    else:
+    else: #heap모듈은 최솟값만 지원해주기 때문에 음수부호를 붙여 최댓값을 최솟값으로 변환
         hq.heappush(heap, -x) #heap에 -x저장

--- a/tttyoung/week_22/boj_11286_절댓값힙.py
+++ b/tttyoung/week_22/boj_11286_절댓값힙.py
@@ -1,16 +1,16 @@
-import heapq as hq 
+import heapq as hq #heap 모듈사용
 import sys
 input = sys.stdin.readline
 
 n = int(input())
-heap = []
+heap = [] 
 
-for i in range(n):
+for i in range(n): 
     x = int(input())
-    if x == 0:
+    if x == 0: #x==0일때 heappop을 하여 출력
         if len(heap) == 0:
             print(0)
         else:
-            print(hq.heappop(heap)[1]) 
+            print(hq.heappop(heap)[1]) #[1]을 통해 절댓값이 아닌 원본 숫자 출력
     else:
-        hq.heappush(heap, (abs(x), x)) #heap에 저장할때 튜플로 저장
+        hq.heappush(heap, (abs(x), x)) #heap에 저장할때 (절댓값, 원본숫자)를 튜플로 저장

--- a/tttyoung/week_22/boj_1789_수들의합.py
+++ b/tttyoung/week_22/boj_1789_수들의합.py
@@ -1,10 +1,11 @@
 s = int(input())
 num = 0
-i = 0
-count = 0
+i = 0 #더해주는 숫자
+count = 0 #숫자 개수
 
+#while문 반복동안 num, i, count늘려가며 최대숫자 찾기
 while True:
-    if num > s:
+    if num > s: #num>s이면 이보다 한개 적은 숫자가 최대개수가 됨
         print(count-1) #count-1이 최대 개수
         break
         


### PR DESCRIPTION
 ### [boj] / 11279_최대힙 / 실버2 / 10분

- 기본적으로 파이썬에서 제공하는 heap모듈에서는 pop을 했을때 heap에 들어있는 최솟값만 제공한다.
- heappush를 해줄때 (-)를 붙여서 음수로 저장 후 최솟값을 추출하고 print할때 다시 부호를 바꿔줘야 최댓값을 추출할 수 있다.
 `hq.heappush(heap, -x) `

### [boj] / 11286_절댓값힙 / 실버1 / 30분

- 처음에는 최대힙 문제처럼 음수로 저장하면 되는줄 알았지만 추출할때 절댓값이 아닌 원래의 숫자로 추출해야하기 때문에 다르게 풀어야한다.
- 음수일때와 양수일때를 나누어서 코드를 작성하다가 heap에 튜플로 값을 저장해도된다는걸 알고 튜플로 절댓값과 원래의 값을 같이 묶어서 저장. 이때 절댓값을 앞에 써줘야지 pop을 할때 절댓값이 같으면 원래의 값이 더 작은 값을 추출할 수 있다.
`hq.heappush(heap, (abs(x), x))`
- `print(hq.heappop(heap)[1]) ` print할때는 이와같이 [1]을 붙여 튜플에서 1번 index에 있는 값인 원래의 값을 추출할 수 있다.

### [boj] / 1789_수들의합 / 실버5 / 10분

- 간단한 그리디 알고리즘 문제로 처음에는 정확한 i값을 구하도록 하려고 했으나 문제의 정답만 구하는데에는 상관이 없어서 굳이 구하지 않음.
- 만약 num>s가 된다면 마지막 i값을 빼준 후 1씩 더해주면서 s에 맞는 값을 찾게 해주는것이지만 어차피 이때 count의 개수는 똑같기 때문에 바로 `print(count-1)`을 해줌.