### PR TITLE
이학진 / 11주차 / 3문제

### DIFF
--- a/leekak/week11/[BOJ]11279.cpp
+++ b/leekak/week11/[BOJ]11279.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <set>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+    int N;
+    cin >> N;
+    multiset<int> DS;
+    while(N--) {
+        int tmp;
+        cin >> tmp;
+        if(tmp == 0) {
+            if(DS.empty()) cout << 0 << "\n";
+            else {
+                auto it = DS.end();
+                it--;
+                cout << *it << "\n";
+                DS.erase(it);
+            }
+        } else {
+            DS.insert(tmp);
+        }
+    }
+    return 0;
+}

--- a/leekak/week11/[BOJ]1927.cpp
+++ b/leekak/week11/[BOJ]1927.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <set>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+    int N;
+    cin >> N;
+    multiset<int> DS;
+    while(N--) {
+        int tmp;
+        cin >> tmp;
+        if(tmp == 0) {
+            if(DS.empty()) cout << 0 << "\n";
+            else {
+                cout << *DS.begin() << "\n";
+                DS.erase(DS.begin());
+            }
+        } else {
+            DS.insert(tmp);
+        }
+    }
+    return 0;
+}

--- a/leekak/week11/[BOJ]2606.cpp
+++ b/leekak/week11/[BOJ]2606.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+// 인접 리스트
+vector<vector<int>> graph;
+vector<bool> visited;
+// 감염된 컴퓨터 수
+int cnt=0;
+
+void dfs(int here) {
+    cnt++;
+    visited[here] = true;
+    // 연결된 모든 인접 노드 탐색
+    for(int i=0; i<graph[here].size(); i++) {
+        int visit = graph[here][i];
+        if(!visited[visit]) dfs(visit);  // 방문 안 했다면 -> 재귀적으로 방문
+    }
+}
+
+int main() {
+    int n_com, n_net;
+    cin >> n_com >> n_net;
+    for(int i=0; i<n_com+1; i++) {
+        vector<int> v;
+        graph.push_back(v);
+    }
+    for(int i=0; i<n_net; i++) {
+        int a, b;
+        cin >> a >> b;
+        graph[a].push_back(b);
+        graph[b].push_back(a);
+    }
+    // 방문 배열 초기화
+    visited = vector<bool> (graph.size(), false);
+    dfs(1);
+    // 자기 자신을 제외한 감염 컴퓨터 수 출력
+    cout << cnt-1;
+    return 0;
+}


### PR DESCRIPTION
### [BOJ] 1927 / Silver2 / 30분

- STL의 multiset을 이용하여 최소 힙을 구현함
- multiset은 중복을 허용하며 입력과 동시에 원소를 오름차순으로 정렬함

### [BOJ] 11279 / Silver2 / 10분

- STL의 multiset을 이용하여 최대 힙을 구현함
- iterator를 end()를 이용해 container의 마지막의 원소의 다음을 가리키도록 하여 최대 힙을 구현
- 선언 시 greater<int> 를 통해 내림차순으로 정렬했어도 됐을 것 같음

### [BOJ] 2606 / Silver3 / 20분

- DFS를 이용해 1번 컴퓨터와 연결된 모든 컴퓨터를 방문함
- 최종 개수를 셀 때 방문한 노드 수에서 자기자신(1번 컴퓨터)을 제외한 개수를 세야함