### PR TITLE
이지원 / 14주차 / 3문제

### DIFF
--- a/2-z-won/week_14/BOJ_1094_막대기.py
+++ b/2-z-won/week_14/BOJ_1094_막대기.py
@@ -1,0 +1,2 @@
+X = int(input())
+print(bin(X).count('1'))

--- a/2-z-won/week_14/BOJ_1257_엄청난 부자.py
+++ b/2-z-won/week_14/BOJ_1257_엄청난 부자.py
@@ -1,0 +1,33 @@
+import sys, heapq
+
+input = sys.stdin.readline
+M = int(input().strip())
+N = int(input().strip())
+coins = list(map(int, input().split()))
+
+# 중복 제거 (불필요한 완화 줄이기)
+coins = sorted(set(coins))
+m = max(coins)
+
+INF = 10**30
+dist = [INF] * m
+dist[0] = 0
+hq = [(0, 0)]  # (비용 W, residue)
+
+# 다익스트라: 엣지 가중치 = m - a, 이동: r -> (r + a) % m
+while hq:
+    d, r = heapq.heappop(hq)
+    if d != dist[r]:
+        continue
+    for a in coins:
+        nr = r + a
+        if nr >= m:
+            nr -= m
+        nd = d + (m - a)
+        if nd < dist[nr]:
+            dist[nr] = nd
+            heapq.heappush(hq, (nd, nr))
+
+r = M % m
+ans = (M + dist[r]) // m
+print(ans)

--- a/2-z-won/week_14/BOJ_1753_최단경로.py
+++ b/2-z-won/week_14/BOJ_1753_최단경로.py
@@ -1,0 +1,31 @@
+import sys
+import heapq
+
+input = sys.stdin.readline
+V, E = map(int, input().split())
+K = int(input())
+
+graph = [[] for _ in range(V + 1)]
+for _ in range(E):
+    u, v, w = map(int, input().split())
+    graph[u].append((v, w))
+
+INF = 10**18
+dist = [INF] * (V + 1)
+dist[K] = 0
+hq = [(0, K)]  # (현재까지 비용, 정점)
+
+while hq:
+    d, u = heapq.heappop(hq)
+    if d != dist[u]:
+        continue
+    for v, w in graph[u]:
+        nd = d + w
+        if nd < dist[v]:
+            dist[v] = nd
+            heapq.heappush(hq, (nd, v))
+
+out = []
+for i in range(1, V + 1):
+    out.append(str(dist[i]) if dist[i] < INF else "INF")
+print("\n".join(out))


### PR DESCRIPTION
[백준] 골드4 / 최단경 로 / 30분

다익스트라 알고리즘을 사용하는 간단한 구현 문제 파이썬 내부의 heapq라이브러리를 사용하였다. 알고리즘의 내용을 알고 있었기 때문에 쉽게 풀 수 있었다. 

[백준] 다이아몬드5 / 엄청난 부자 / 20분(정답참조)

앞선 문제와 같이 다익스트라 알고리즘의 응용문제. 같은 토픽에 있길래 어려우면 얼마나 어려울까 하고 접근하였다가 어떻게 다익스트라를 사용하는지도 생각하지 못하였다. 정답을 참고한결과 mod그래프에서 다익스트라 알고리즘을 사용하면 된다고 하였다. 잔여값을  0..m-1를 정점으로 두고, 동전 a를 쓰면 x → (x+a) % m 로 이동, 엣지 가중치는 m - a 로 두는게 이 문제를 푸는데 제일 핵심적인 아이디어이다. 이후 구현은 그렇게 힘들지 않았다. 


[백준] 실버5 / 막대기 / 3분

이진수로 변환 후 1의 갯수를 세는 문제. 아이디어가 정말 좋았다. 