### PR TITLE
김진우 / 25주차 / 3문제

### DIFF
--- a/maureen272/week25/BOJ-1676.py
+++ b/maureen272/week25/BOJ-1676.py
@@ -1,0 +1,11 @@
+# BOJ : 1676 - 팩토리얼 0의 개수
+N = int(input())
+count = 0
+
+# N!에 들어있는 5의 개수를 누적해서 셈
+i = 5
+while N // i > 0:
+    count += N // i
+    i *= 5
+
+print(count)

--- a/maureen272/week25/Leetcode-239-SlidingWindowMaximum.py
+++ b/maureen272/week25/Leetcode-239-SlidingWindowMaximum.py
@@ -1,0 +1,11 @@
+class Solution(object):
+    def maxSlidingWindow(self, nums, k):
+        """
+        :type nums: List[int]
+        :type k: int
+        :rtype: List[int]
+        """
+        ans = []
+        for i in range(len(nums)- k + 1):
+            ans.append(max(nums[i:i+k]))
+        return ans

--- a/maureen272/week25/Leetcode-76-MinimumWindowSubstring.py
+++ b/maureen272/week25/Leetcode-76-MinimumWindowSubstring.py
@@ -1,0 +1,27 @@
+class Solution(object):
+    def minWindow(self, s, t):
+        """
+        :type s: str
+        :type t: str
+        :rtype: str
+        """
+        need = collections.Counter(t) # t에 필요한 문자 개수
+        missing = len(t) # 필요한 문자의 전체 개수
+        left = start = end = 0 
+
+        # 오른쪽 포인터 이동
+        for right, char in enumerate(s,1): # right는 1부터 시작 ->  ennumerate(s,1)은 1부터 시작한다는 의미
+            # 필요 문자 개수 감소
+            missing -= need[char] > 0 # 필요 문자가 있으면 missing 감소
+            need[char] -= 1 
+
+            # 필요 문자가 0이면(missing==0) 왼쪽 포인터 이동 판단
+            if missing == 0: 
+                while left < right and need[s[left]] < 0: # 왼쪽 포인터가 불필요한 문자를 가리키면 값이 음수일 것임
+                    need[s[left]] += 1
+                    left += 1
+
+                if not end or right - left <= end - start: # 최소 길이 갱신
+                    start, end = left, right # end는 right + 1
+                # missing이 0이 될때까지의 오른쪽 포인터와 need[s[left]]가 0이 될 때까지의 왼쪽 포인터를 정답으로 간주하고
+                # 이 값이 더 작은 값을 찾을 때까지 유지하다, 가장 작은 값의 경우 그 값을 리턴


### PR DESCRIPTION
### [Leetcode] Sliding Window Maximum / hard / 40min
- 배열이 주어졌을때 K 크기만큼의 슬라이딩 윈도우를 오른쪽으로 끝까지 이동한 최대 슬라이딩 윈도우를 구하는 문제로 처음에 주어진 예시 입출력을 이해하는데 시간이 오래걸림
- 각 슬라이딩 윈도우 내의 최댓값을 전부 출력하는 문제였고 간단하게 생각했을 때는 그냥 반복문을 돌면서 max()를 사용해서 문제를 풀면 해결할 수 있었음
- 그러나 이런 방식은 매번 윈도우의 최댓값을 계산해야해서 시간복잡도가 O(n)으로 매우 높았고 예시답안을 보니 큐를 이용하여 풀었길래 큐를 이용한 풀이도 읽어보니 필요할 때만 최댓값을 계산하고 그 이외에는 새로 추가되는 값이 최대인지만 확인하여 시간 복잡도를 확 줄였음을 알 수 있었음

###[Leetcode] Minimum Window Substring / hard / 1hr 20min
- 문자열 S와 T를 입력받아서 주어진 시간복잡도 내에 T의 모든 문자가 포함된 S의 최소 윈도우를 찾는 문제인데 사실 브루트포스로 코드를 구현하면 풀리긴할텐데 이 경우 시간복잡도가 O(n^2) 쯤일꺼라 주어진 시간복잡도인 O(n)를 넘어버려서 빠르게 다른 방법을 생각함
- 슬라이딩 윈도우의 경우 투포인터를 사용하면 문제를 해결할 수 있는 경우가 많아서 투포인터로 접근을 했는데 투포인터로만 풀려고하니까 문제가 안풀림
- 해설을 참고해보니 투포인터만 쓰는것이 아니라 슬라이딩 윈도우를 사용하면서 적절한 위치에서부터 좌우 포인터의 크기를 줄여가는 투 포인터로 구현을 해야하는 문제였음
- 근데 푸는 방법을 알아도 
```
if missing == 0: 
                while left < right and need[s[left]] < 0: # 왼쪽 포인터가 불필요한 문자를 가리키면 값이 음수일 것임
                    need[s[left]] += 1
                    left += 1
```
이 부분을 생각해내는데 시간이 좀 오래 걸렸음

### [BOJ] 팩토리얼 0의 개수 / silver5 / 25min
- N!에서 뒤에서부터 처음 0이 아닌 숫자가 나올 때까지 0의 개수를 구하는 문제
- 어떻게 풀지 생각할때 끝에 0이 생기는 경우를 떠올려보면 5*2*n 인 경우에만 0이 생김을 알 수 있음
- 이 말은 곧 N!의 끝 0의 개수 == N!에 포함된 (2,5)쌍의 개수이고 즉 5의 개수만 세면 이 문제를 해결할 수 있었음