### PR TITLE
이학진 / 20주차 / 3문제

### DIFF
--- a/leekak/week20/[BOJ]1780.py
+++ b/leekak/week20/[BOJ]1780.py
@@ -1,0 +1,65 @@
+import sys
+sys.setrecursionlimit(3000)
+
+cnt_n = 0    # -1로 채워진 종이 개수
+cnt_zero = 0 # 0으로 채워진 종이 개수
+cnt_p = 0    # 1로 채워진 종이 개수
+paper = []   # 종이 배열
+
+def cut_paper(x, y, N):
+    global cnt_n, cnt_zero, cnt_p
+
+    standard_value = paper[y][x]
+    is_uniform = True  # 영역이 균일한지 (하나의 값으로만 이루어졌는지) 확인
+
+    # N*N 영역을 순회하며 확인
+    for r in range(y, y + N):
+        for c in range(x, x + N):
+            if paper[r][c] != standard_value:
+                is_uniform = False
+                break
+        if not is_uniform:
+            break
+
+    # 영역이 균일하지 않으면 (is_uniform == False) 9개의 작은 영역으로 분할하여 재귀 호출
+    if not is_uniform:
+        next_N = N // 3
+        
+        # 3x3 분할하여 재귀 호출
+        
+        cut_paper(x, y, next_N)
+        cut_paper(x + next_N, y, next_N)
+        cut_paper(x + 2 * next_N, y, next_N)
+        
+        cut_paper(x, y + next_N, next_N)
+        cut_paper(x + next_N, y + next_N, next_N)
+        cut_paper(x + 2 * next_N, y + next_N, next_N)
+        
+        cut_paper(x, y + 2 * next_N, next_N)
+        cut_paper(x + next_N, y + 2 * next_N, next_N)
+        cut_paper(x + 2 * next_N, y + 2 * next_N, next_N)
+
+    # 영역이 균일하면 (is_uniform == True) 개수를 카운트
+    else:
+        if standard_value == -1:
+            cnt_n += 1
+        elif standard_value == 0:
+            cnt_zero += 1
+        elif standard_value == 1:
+            cnt_p += 1
+
+if __name__ == "__main__":
+    try:
+        N = int(sys.stdin.readline())
+    except:
+        N = 0
+      
+    for _ in range(N):
+        # sys.stdin.readline()을 사용하면 한 줄 전체를 읽으므로, split()과 map(int, ...)를 사용해 리스트로 만듭니다.
+        # strip()으로 개행 문자를 제거합니다.
+        line = list(map(int, sys.stdin.readline().strip().split()))
+        paper.append(line)
+
+    cut_paper(0, 0, N)
+
+    print(f"{cnt_n}\n{cnt_zero}\n{cnt_p}")

--- a/leekak/week20/[BOJ]2164.py
+++ b/leekak/week20/[BOJ]2164.py
@@ -1,0 +1,23 @@
+import sys
+from collections import deque
+
+def solve():
+    try:
+        # sys.stdin.readline()은 개행 문자를 포함하므로 strip()으로 제거
+        N = int(sys.stdin.readline().strip())
+    except:
+        print(1) 
+        return
+      
+    Q = deque(range(1, N + 1))
+
+    while len(Q) > 1:
+        Q.popleft() 
+        card_to_move = Q.popleft()
+        Q.append(card_to_move)
+
+    if Q:
+        print(Q[0]) # 또는 print(Q.popleft())
+
+if __name__ == "__main__":
+    solve()

--- a/leekak/week20/[BOJ]2751.py
+++ b/leekak/week20/[BOJ]2751.py
@@ -1,0 +1,18 @@
+import sys
+
+def solve():
+    try:
+        N = int(sys.stdin.readline().strip())
+    except:
+        return
+      
+    arr = []
+    for _ in range(N):
+        arr.append(int(sys.stdin.readline().strip()))
+
+    arr.sort() 
+
+    sys.stdout.write('\n'.join(map(str, arr)))
+
+if __name__ == "__main__":
+    solve()


### PR DESCRIPTION
### 지난 주에 풀었던 문제들을 파이썬 코드로 변경함
(당분간 C++ 안 할 거임)

### 1780

- 파이썬에서는 기본 재귀 깊이 제한이 있으므로 sys.setrecursionlimit(3000)을 추가하여 그 크기를 늘림
- sys.stdin.readline()을 사용해 한 줄씩 입력받은 뒤 split()과 map을 이용해 정수 리스트로 변환

### 2164

- 양 방향에서 데이터를 추가/제거할 수 있는 deque 사용
- cpp stl의 queue에서 pop()에는 반환값없이 맨 위 요소 제거만 수행하는 반면 python의 deque에서 popleft()는 맨 앞 요소 제거와 함께 값도 반환한다.

### 2751

- sys.stdin.readline().strip()로 입력으로부터 쉽게 개행 제거 가능